### PR TITLE
UPS code for UPS Today Standard corrected

### DIFF
--- a/lib/shipConfirm.js
+++ b/lib/shipConfirm.js
@@ -267,7 +267,7 @@ ShipConfirm.prototype.makeRequest = function(options, callback) {
 						code = 'M6';
 						break;
 					case 'ups today standard':
-						code = '86';
+						code = '82';
 						break;
 					case 'ups today dedicated courier':
 						code = '83';

--- a/lib/shipConfirm.js
+++ b/lib/shipConfirm.js
@@ -239,7 +239,7 @@ ShipConfirm.prototype.makeRequest = function(options, callback) {
 					case 'next day air saver':
 						code = '13';
 						break;
-					case 'next day air airly am':
+					case 'next day air early am':
 						code = '14';
 						break;
 					case 'express plus':


### PR DESCRIPTION
according to the XML guide from UPS the shipping method "UPS Today Standard" has code 82
